### PR TITLE
implement a show connected wallet info #4

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -5,10 +5,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { hardhat } from "viem/chains";
-import { useAccount } from "wagmi";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
-import { useOutsideClick, useScaffoldReadContract, useTargetNetwork } from "~~/hooks/scaffold-eth";
+import { useOutsideClick, useTargetNetwork , useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+import { useAccount } from 'wagmi';
+
 
 type HeaderMenuLink = {
   label: string;
@@ -76,16 +77,15 @@ export const Header = () => {
     functionName: "allowList",
     args: [address],
   });
-
+  
   // Check if address is checked in
   const { data: checkedInContractAddress } = useScaffoldReadContract({
     contractName: "BatchRegistry",
     functionName: "yourContractAddress",
     args: [address],
   });
-
-  const isCheckedIn =
-    checkedInContractAddress && checkedInContractAddress !== "0x0000000000000000000000000000000000000000";
+  
+  const isCheckedIn = checkedInContractAddress && checkedInContractAddress !== "0x0000000000000000000000000000000000000000";
 
   return (
     <div className="sticky lg:static top-0 navbar bg-base-100 min-h-0 flex-shrink-0 justify-between z-20 shadow-md shadow-secondary px-0 sm:px-2">
@@ -132,11 +132,7 @@ export const Header = () => {
             {isBatchMember && (
               <div className="tooltip tooltip-bottom" data-tip="Batch Member">
                 <svg className="w-5 h-5 text-green-500" fill="currentColor" viewBox="0 0 20 20">
-                  <path
-                    fillRule="evenodd"
-                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                    clipRule="evenodd"
-                  />
+                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                 </svg>
               </div>
             )}
@@ -144,11 +140,7 @@ export const Header = () => {
               <div className="tooltip tooltip-bottom" data-tip="Checked In">
                 <svg className="w-5 h-5 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z" />
-                  <path
-                    fillRule="evenodd"
-                    d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z"
-                    clipRule="evenodd"
-                  />
+                  <path fillRule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clipRule="evenodd" />
                 </svg>
               </div>
             )}
@@ -160,3 +152,4 @@ export const Header = () => {
     </div>
   );
 };
+

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -5,9 +5,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { hardhat } from "viem/chains";
+import { useAccount } from "wagmi";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
-import { useOutsideClick, useTargetNetwork } from "~~/hooks/scaffold-eth";
+import { useOutsideClick, useScaffoldReadContract, useTargetNetwork } from "~~/hooks/scaffold-eth";
 
 type HeaderMenuLink = {
   label: string;
@@ -67,6 +68,25 @@ export const Header = () => {
     useCallback(() => setIsDrawerOpen(false), []),
   );
 
+  const { address } = useAccount();
+
+  // Check if address is in allowList
+  const { data: isBatchMember } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "allowList",
+    args: [address],
+  });
+
+  // Check if address is checked in
+  const { data: checkedInContractAddress } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "yourContractAddress",
+    args: [address],
+  });
+
+  const isCheckedIn =
+    checkedInContractAddress && checkedInContractAddress !== "0x0000000000000000000000000000000000000000";
+
   return (
     <div className="sticky lg:static top-0 navbar bg-base-100 min-h-0 flex-shrink-0 justify-between z-20 shadow-md shadow-secondary px-0 sm:px-2">
       <div className="navbar-start w-auto lg:w-1/2">
@@ -105,7 +125,35 @@ export const Header = () => {
           <HeaderMenuLinks />
         </ul>
       </div>
-      <div className="navbar-end flex-grow mr-4">
+
+      <div className="navbar-end flex-grow mr-4 flex items-center gap-2">
+        {address && (
+          <div className="flex items-center gap-1">
+            {isBatchMember && (
+              <div className="tooltip tooltip-bottom" data-tip="Batch Member">
+                <svg className="w-5 h-5 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+            )}
+            {isCheckedIn && (
+              <div className="tooltip tooltip-bottom" data-tip="Checked In">
+                <svg className="w-5 h-5 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z" />
+                  <path
+                    fillRule="evenodd"
+                    d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+            )}
+          </div>
+        )}
         <RainbowKitCustomConnectButton />
         {isLocalNetwork && <FaucetButton />}
       </div>


### PR DESCRIPTION
## Description
This PR adds visual indicators for batch membership and check-in status next to the wallet connection button. Users can now see at a glance:
- ✅ Green checkmark if their address is in the batch `allowList`
- 📝 Blue document icon if they've successfully checked in

## Changes
- Added status icons with bottom-positioned tooltips
- Integrated with `BatchRegistry` contract reads
- Maintained existing navbar layout and responsiveness
- Used only available project hooks (`useScaffoldReadContract`)

## Screenshot
![Screenshot 2025-04-11 at 11 59 56 PM (3)](https://github.com/user-attachments/assets/1d63638e-e554-47b1-9045-307ebcff6aa5)
![Screenshot 2025-04-12 at 12 00 47 AM (3)](https://github.com/user-attachments/assets/764eb3d5-e525-4834-b1d5-b16c97cf6460)


## Testing
- Verified icons appear only for connected wallets
- Confirmed tooltips show correct information
- Checked mobile responsiveness

## Related Issue
Closes #04

My Ethereum Address
0x575109e921C6d6a1Cb7cA60Be0191B10950AfA6C


